### PR TITLE
Improve testing behavior

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,12 +16,9 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake)
 include(gifti_macros)
 
 
-option(TEST_GIFTI "Enable tests" ON)
-if(${TEST_GIFTI})
-    enable_testing()
-endif()
 option(BUILD_SHARED_LIBS "Toggle building shared libraries." ON)
 add_definitions(-DHAVE_ZLIB)
+set_if_not_defined(DOWNLOAD_TEST_DATA 1)
 
 find_package(ITK)
 if(ITK_FOUND)
@@ -99,9 +96,11 @@ endif()
 #
 # Testing
 
-# enable_testing() sets the following variable:
-if(${CMAKE_TESTING_ENABLED})
+set_if_not_defined(BUILD_TESTING ON)
+set_if_not_defined(GIFTI_BUILD_TESTING ${BUILD_TESTING})
+if(GIFTI_BUILD_TESTING AND GIFTI_BUILD_APPLICATIONS)
   include(CTest)
+if(DOWNLOAD_TEST_DATA)
   if(CMAKE_VERSION VERSION_LESS 3.11.0)
     # CMAKE VERSION 3.11.0 needed for fetching data with cmake
     message(
@@ -112,7 +111,7 @@ if(${CMAKE_TESTING_ENABLED})
 
   include(FetchContent) # fetch data a configure time to simplify tests If new
                         # or changed data is needed, add that data to the
-                        # https://github.com/NIFTI-Imaging/nifti-test-data repo
+                        # https://github.com/NIFTI-Imaging/gifti-test-data repo
                         # make a new release, and then update the URL and hash
                         # (shasum -a 256 <downloaded tarball>).
   fetchcontent_declare(
@@ -122,8 +121,11 @@ if(${CMAKE_TESTING_ENABLED})
     URL_HASH
     SHA256=9b97e830ad27a82efcacb41ea3a7c573b34b7b3ca47e0c0bfb65b44f604199c2)
   fetchcontent_getproperties(gifti_test_data)
-  set(FETCHCONTENT_QUIET OFF)
-  fetchcontent_populate(gifti_test_data)
+  if(NOT gifti_test_data_POPULATED)
+    set(FETCHCONTENT_QUIET OFF)
+    FetchContent_Populate( gifti_test_data )
+  endif()
+endif()
 endif()
 
 set(TEST_SCRIPT_DIR ${CMAKE_CURRENT_LIST_DIR}/regress_tests/cmake_test_scripts)
@@ -139,47 +141,56 @@ add_test(NAME gifti_disp_hdr
          COMMAND $<TARGET_FILE:gifti_tool> 
                  -disp_hdr 
                  -infiles ${TEST_DATA}/anat0.nii)
+set_tests_properties( gifti_disp_hdr PROPERTIES LABELS NEEDS_DATA)
 add_test(NAME gifti_disp_nim
          COMMAND $<TARGET_FILE:gifti_tool> 
                  -disp_nim 
                  -infiles ${TEST_DATA}/anat0.nii)
+set_tests_properties( gifti_disp_nim PROPERTIES LABELS NEEDS_DATA)
 add_test(NAME gifti_disp_ext
          COMMAND $<TARGET_FILE:gifti_tool> 
                  -disp_ext 
                  -infiles ${TEST_DATA}/anat0.nii)
+set_tests_properties( gifti_disp_ext PROPERTIES LABELS NEEDS_DATA)
 add_test(NAME gifti_header_check
          COMMAND $<TARGET_FILE:gifti_tool> 
                  -check_hdr 
                  -infiles ${TEST_DATA}/anat0.nii)
+set_tests_properties( gifti_header_check PROPERTIES LABELS NEEDS_DATA)
 add_test(NAME gifti_nim_check
          COMMAND $<TARGET_FILE:gifti_tool> 
                  -check_nim 
                  -infiles ${TEST_DATA}/anat0.nii)
+set_tests_properties( gifti_nim_check PROPERTIES LABELS NEEDS_DATA)
 add_test(NAME gifti_pial_short_verbose
         COMMAND $<TARGET_FILE:gifti_tool> 
                  -check_nim 
                  -infile ${TEST_DATA}/ascii.pial.short.gii)
+set_tests_properties( gifti_pial_short_verbose PROPERTIES LABELS NEEDS_DATA)
 add_test(NAME gifti_show_color_table_gifti
         COMMAND $<TARGET_FILE:gifti_tool> 
                 -show_gifti
                 -infile ${TEST_DATA}/color.table.gii)
+set_tests_properties( gifti_show_color_table_gifti PROPERTIES LABELS NEEDS_DATA)
 add_test(NAME gifti_show_surfs
         COMMAND $<TARGET_FILE:gifti_tool> 
                 -show_gifti
                 -infile ${TEST_DATA}/b64gz.ts.3.gii)
+set_tests_properties( gifti_show_surfs PROPERTIES LABELS NEEDS_DATA)
 
 
 
 if(UNIX) # unix needed to run shell scripts
- 
+
  foreach(test_stubname no_data_flag no_updates_flag high_verbosity copy_surfs
   b64_check buf_size encode indent compress other_formats new_dsets fix_errors
   modify_and_compare approx label_table col_maj_1 col_maj_2 extern_data)
-  
+
   add_test(
     NAME gifti_${test_stubname}
     COMMAND bash -xeu ${TEST_SCRIPT_DIR}/${test_stubname}.sh
             $<TARGET_FILE:gifti_tool>
             ${TEST_DATA})
+  set_tests_properties( gifti_${test_stubname} PROPERTIES LABELS NEEDS_DATA)
   endforeach()
 endif()


### PR DESCRIPTION
Add support for optional test data download

Add label to tests that need test data

Use GIFTI_BUILD_TESTING, then BUILD_TESTING if set,otherwise default to
using testing